### PR TITLE
Add macos support

### DIFF
--- a/Assets/RustNative/Editor/RustNativeEditor.cs
+++ b/Assets/RustNative/Editor/RustNativeEditor.cs
@@ -26,7 +26,7 @@ public class RustNativeEditor : EditorWindow
     [SerializeField] private VisualTreeAsset projectUXML;
 
     public static readonly string UnityFolder = Path.GetDirectoryName(Application.dataPath);
-    public static readonly string RustNativeFolder = Path.Join(UnityFolder, "RustNative");
+    public static readonly string RustNativeFolder = Path.Combine(UnityFolder, "RustNative");
 
     [MenuItem("Window/Rust Native Manager")]
     public static void ShowWindow()
@@ -88,8 +88,8 @@ public class RustNativeEditor : EditorWindow
 
         try
         {
-            string projectDir = Path.Join(RustNativeFolder, projectName);
-            string projectUnityDir = Path.Join(Application.dataPath, "RustNative", projectName);
+            string projectDir = Path.Combine(RustNativeFolder, projectName);
+            string projectUnityDir = Path.Combine(Application.dataPath, "RustNative", projectName);
 
             EditorUtility.DisplayProgressBar($"Rebuilding '{projectName}' Bindings", "Building library...", 0.4f);
             Process cargo = new Process();
@@ -129,13 +129,13 @@ public class RustNativeEditor : EditorWindow
 #endif
 
             string libraryUnityName = $"{projectName}-{randomId}";
-            string targetDir = Path.Join(projectDir, "target", "release");
-            string libraryPath = Path.Join(targetDir, libraryFilename);
-            File.Copy(libraryPath, Path.Join(projectUnityDir, libraryUnityFilename));
+            string targetDir = Path.Combine(projectDir, "target", "release");
+            string libraryPath = Path.Combine(targetDir, libraryFilename);
+            File.Copy(libraryPath, Path.Combine(projectUnityDir, libraryUnityFilename));
 
             string bindingFilename = $"{projectName}.cs";
-            string bindingPath = Path.Join(Path.Join(projectDir, "bindings", "csharp"), bindingFilename);
-            string bindingUnityPath = Path.Join(projectUnityDir, bindingFilename);
+            string bindingPath = Path.Combine(Path.Combine(projectDir, "bindings", "csharp"), bindingFilename);
+            string bindingUnityPath = Path.Combine(projectUnityDir, bindingFilename);
             string bindingText = File.ReadAllText(bindingPath);
             bindingText = bindingText.Replace($"public const string NativeLib = \"{projectName}\";", $"public const string NativeLib = \"{libraryUnityName}\";");
             File.WriteAllText(bindingUnityPath, bindingText);
@@ -196,7 +196,7 @@ public class RustNativeEditor : EditorWindow
 
 public class RustNativeConfig
 {
-    public static readonly string ConfigLocation = Path.Join(RustNativeEditor.RustNativeFolder, "config.json");
+    public static readonly string ConfigLocation = Path.Combine(RustNativeEditor.RustNativeFolder, "config.json");
 
     [SerializeField] private string cargoLocation;
 

--- a/Assets/RustNative/Editor/RustNativeEditor.cs
+++ b/Assets/RustNative/Editor/RustNativeEditor.cs
@@ -126,6 +126,9 @@ public class RustNativeEditor : EditorWindow
 #elif UNITY_EDITOR_WIN
             string libraryFilename = $"{projectName}.dll";
             string libraryUnityFilename = $"{projectName}-{randomId}.dll";
+#elif UNITY_EDITOR_OSX
+            string libraryFilename = $"lib{projectName}.dylib";
+            string libraryUnityFilename = $"{projectName}-{randomId}.dylib";
 #endif
 
             string libraryUnityName = $"{projectName}-{randomId}";

--- a/Assets/RustNative/Editor/RustNativeNewProjectEditor.cs
+++ b/Assets/RustNative/Editor/RustNativeNewProjectEditor.cs
@@ -33,22 +33,22 @@ public class RustNativeNewProjectEditor : EditorWindow
         try
         {
             EditorUtility.DisplayProgressBar("Creating New Rust Native Project", "Extracting template...", 0.2f);
-            string projectTemplateZip = Path.Join(Path.Join(Application.dataPath, "RustNative", "Editor"), "template_rust_library.zip");
+            string projectTemplateZip = Path.Combine(Path.Combine(Application.dataPath, "RustNative", "Editor"), "template_rust_library.zip");
             ZipFile.ExtractToDirectory(projectTemplateZip, RustNativeEditor.RustNativeFolder);
 
             EditorUtility.DisplayProgressBar("Creating New Rust Native Project", "Renaming template...", 0.5f);
-            string templateDir = Path.Join(RustNativeEditor.RustNativeFolder, "template_rust_library");
-            string projectDir = Path.Join(RustNativeEditor.RustNativeFolder, projectName);
+            string templateDir = Path.Combine(RustNativeEditor.RustNativeFolder, "template_rust_library");
+            string projectDir = Path.Combine(RustNativeEditor.RustNativeFolder, projectName);
             Directory.Move(templateDir, projectDir);
 
             EditorUtility.DisplayProgressBar("Creating New Rust Native Project", "Updating Cargo TOML...", 0.6f);
-            string tomlFile = Path.Join(projectDir, "Cargo.toml");
+            string tomlFile = Path.Combine(projectDir, "Cargo.toml");
             string tomlText = File.ReadAllText(tomlFile);
             tomlText = tomlText.Replace("template_rust_library", projectName);
             File.WriteAllText(tomlFile, tomlText);
 
             EditorUtility.DisplayProgressBar("Creating New Rust Native Project", "Updating binding generator...", 0.7f);
-            string testFile = Path.Join(projectDir, "tests", "bindings.rs");
+            string testFile = Path.Combine(projectDir, "tests", "bindings.rs");
             string testText = File.ReadAllText(testFile);
             testText = testText.Replace("template_rust_library", projectName);
             File.WriteAllText(testFile, testText);
@@ -56,7 +56,7 @@ public class RustNativeNewProjectEditor : EditorWindow
         catch (Exception e)
         {
             EditorUtility.ClearProgressBar();
-            Directory.Delete(Path.Join(RustNativeEditor.RustNativeFolder, "template_rust_library"));
+            Directory.Delete(Path.Combine(RustNativeEditor.RustNativeFolder, "template_rust_library"));
             return e.Message;
         }
 

--- a/Assets/csc.rsp
+++ b/Assets/csc.rsp
@@ -1,0 +1,1 @@
+-r:System.IO.Compression.FileSystem.dll


### PR DESCRIPTION
This PR adds support for macos.

I ran into three distinct issues when trying to get the plugin to load:

1. Several errors complaining about Path.Join being missing (53b17f11c36d1f2885c708d96bd2ef7866b03bff)
2. Missing conditional taking macos into consideration when dealing with the compiled library (dc157b0895734e19008da3d3cdead21a2d04f540)
3. Error referencing ZipFile (e0fcbfdeb897b8c2f0116eac2a349310f2060ebb)

All three _should_ be solved in a way that is still compatible with Linux and Windows, but I only tested it on macos; if you can, please verify before merging the PR.

Thanks!