### PR TITLE
Fix dll access denied error on Windows

### DIFF
--- a/Assets/RustNative/Editor/RustNativeEditor.cs
+++ b/Assets/RustNative/Editor/RustNativeEditor.cs
@@ -116,7 +116,7 @@ public class RustNativeEditor : EditorWindow
             if (cargo.ExitCode != 0) throw new Exception(cargo.StandardError.ReadToEnd());
 
             EditorUtility.DisplayProgressBar($"Rebuilding '{projectName}' Bindings", "Copying library and bind files...", 0.9f);
-            if (Directory.Exists(projectUnityDir)) Directory.Delete(projectUnityDir, true);
+            if (Directory.Exists(projectUnityDir)) AssetDatabase.DeleteAsset(projectUnityDir);
             Directory.CreateDirectory(projectUnityDir);
 
             int randomId = UnityEngine.Random.Range(100000, 999999);

--- a/Assets/RustNative/Editor/RustNativeEditor.cs
+++ b/Assets/RustNative/Editor/RustNativeEditor.cs
@@ -146,7 +146,7 @@ public class RustNativeEditor : EditorWindow
         catch (Exception e)
         {
             EditorUtility.ClearProgressBar();
-            Debug.LogError($"Rust Native Rebuild Binding Error: {e.Message}");
+            Debug.LogError($"Rust Native Rebuild Binding Error: {e.Message} {e.StackTrace}");
             return;
         }
 


### PR DESCRIPTION
## Problem

I encountered the following problem on Windows.

Steps to reproduce:
1. Call Rust code from C#.
2. Run the game in Unity editor.
3. Modify the Rust code, e.g. add 10 to some return value.
4. Click "Rebuild Bindings"

This results in error (where `RustPhysics` is the name of my Rust Native crate).
```
Rust Native Rebuild Binding Error: Access to the path 'RustPhysics-795234.dll' is denied.
UnityEngine.Debug:LogError (object)
RustNativeEditor:RebuildBindings (string) (at Assets/RustNative/Editor/RustNativeEditor.cs:146)
RustNativeEditor/<>c__DisplayClass9_0:<ReloadProjectList>b__0 (UnityEngine.UIElements.ClickEvent) (at Assets/RustNative/Editor/RustNativeEditor.cs:74)
UnityEngine.GUIUtility:ProcessEvent (int,intptr,bool&)
```

## This PR

This PR adds stack trace to the error above (in case similar problems arise in the future), and fixes the error.

Have not tested this on Linux or MacOS.